### PR TITLE
Convert specs to RSpec 3.1.7 syntax with Transpec

### DIFF
--- a/daemon_objects.gemspec
+++ b/daemon_objects.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bunny", "~> 1.1.0"
   spec.add_dependency "rake"
 
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "pry-nav"
   spec.add_development_dependency "memory_logger", "~> 0.0.3"
 end

--- a/spec/lib/daemon_objects/base_spec.rb
+++ b/spec/lib/daemon_objects/base_spec.rb
@@ -9,9 +9,9 @@ describe DaemonObjects::Base do
 
   describe '#app_directory' do
     it 'should be Rake.original_directory if Rails is not defined' do
-      Rake.stub(:original_dir).and_return("/mydir")
+      allow(Rake).to receive(:original_dir).and_return("/mydir")
       MyDaemon = Class.new(DaemonObjects::Base)
-      MyDaemon.app_directory.should == Rake.original_dir
+      expect(MyDaemon.app_directory).to eq(Rake.original_dir)
     end
 
     context 'Rails' do
@@ -29,7 +29,7 @@ describe DaemonObjects::Base do
 
       it 'should be Rails.root is Rails is defined' do
         MyDaemon = Class.new(DaemonObjects::Base)
-        MyDaemon.app_directory.should == Rails.root
+        expect(MyDaemon.app_directory).to eq(Rails.root)
       end
     end
 
@@ -45,7 +45,7 @@ describe DaemonObjects::Base do
   describe '#extends' do
     it 'should extend logging' do
       MyDaemon = Class.new(DaemonObjects::Base)
-      MyDaemon.singleton_class.included_modules.should include(DaemonObjects::Logging)
+      expect(MyDaemon.singleton_class.included_modules).to include(DaemonObjects::Logging)
     end
   end
 
@@ -58,7 +58,7 @@ describe DaemonObjects::Base do
       end
 
       MyDaemon.run
-      MyDaemon.logger.logged_output.should =~ /Starting consumer/
+      expect(MyDaemon.logger.logged_output).to match(/Starting consumer/)
     end
 
   end
@@ -66,7 +66,7 @@ describe DaemonObjects::Base do
   describe '#start' do
     it 'should call daemon run_proc' do
       MyDaemon = Class.new(DaemonObjects::Base)
-      Daemons.should_receive(:run_proc).
+      expect(Daemons).to receive(:run_proc).
         with(MyDaemon.proc_name,
              { :ARGV       => ['start', '-f'],
                :log_dir    => "/tmp",
@@ -80,7 +80,7 @@ describe DaemonObjects::Base do
   describe '#stop' do
     it 'should call daemon stop_proc' do
       MyDaemon = Class.new(DaemonObjects::Base)
-      Daemons.should_receive(:run_proc).
+      expect(Daemons).to receive(:run_proc).
         with(MyDaemon.proc_name,
              { :ARGV => ['stop', '-f'],
               :dir   => MyDaemon.pid_directory})
@@ -92,14 +92,14 @@ describe DaemonObjects::Base do
     it 'should constantize a file with multiple part name' do
       ThreePartNameConsumer = Class.new
       ThreePartNameDaemon = Class.new(DaemonObjects::Base)
-      ThreePartNameDaemon.consumer_class.should == ThreePartNameConsumer
+      expect(ThreePartNameDaemon.consumer_class).to eq(ThreePartNameConsumer)
     end
   end
 
   describe '##proc_name' do
     it 'should underscore class to get daemon name' do
       ThreePartNameDaemon = Class.new(DaemonObjects::Base)
-      ThreePartNameDaemon.proc_name.should == "three_part_name_daemon"
+      expect(ThreePartNameDaemon.proc_name).to eq("three_part_name_daemon")
     end
   end
 
@@ -135,7 +135,7 @@ describe DaemonObjects::Base do
 
     it 'should set environment' do
       DaemonObjects.environment = "theenv"
-      consumer.environment.should == "theenv"
+      expect(consumer.environment).to eq("theenv")
     end
 
     it 'should set app directory' do
@@ -143,14 +143,14 @@ describe DaemonObjects::Base do
         "thedir"
       end
 
-      consumer.app_directory.should == "thedir"
+      expect(consumer.app_directory).to eq("thedir")
     end
 
     it 'should set logger' do
       logger = MemoryLogger::Logger.new
-      MyDaemon.stub(:logger).and_return(logger)
+      allow(MyDaemon).to receive(:logger).and_return(logger)
 
-      consumer.logger.should == logger
+      expect(consumer.logger).to eq(logger)
     end
   end
 
@@ -177,7 +177,7 @@ describe DaemonObjects::Base do
       end
 
       bunny = double(Bunny).as_null_object
-      Bunny.should_receive(:new).with('amqp://localhost:4567').and_return(bunny)
+      expect(Bunny).to receive(:new).with('amqp://localhost:4567').and_return(bunny)
       MyDaemon.run
     end
 
@@ -185,7 +185,7 @@ describe DaemonObjects::Base do
       MyConsumer = Class.new(DaemonObjects::ConsumerBase)
       MyDaemon = Class.new(DaemonObjects::Base)
 
-      Bunny.should_not_receive(:new)
+      expect(Bunny).not_to receive(:new)
       MyDaemon.run
 
     end
@@ -199,23 +199,23 @@ describe DaemonObjects::Base do
       end
 
       bunny = double(Bunny).as_null_object
-      Bunny.stub(:new).and_return(bunny)
+      allow(Bunny).to receive(:new).and_return(bunny)
       channel = double(Bunny::Channel)
-      bunny.stub(:create_channel).and_return(channel)
-      channel.should_not_receive(:prefetch)
+      allow(bunny).to receive(:create_channel).and_return(channel)
+      expect(channel).not_to receive(:prefetch)
 
       worker  = MyWorker.new
       consumer = MyDaemon.get_consumer
-      MyDaemon.stub(:get_consumer).and_return(consumer)
+      allow(MyDaemon).to receive(:get_consumer).and_return(consumer)
 
-      MyWorker.should_receive(:new).
+      expect(MyWorker).to receive(:new).
         with(channel, consumer, {
               :queue_name => 'queue',
               :logger     => MyDaemon.logger,
               :arguments  => {}
         }).
         and_return(worker)
-      worker.should_receive(:start)
+      expect(worker).to receive(:start)
 
       MyDaemon.run
     end
@@ -230,24 +230,24 @@ describe DaemonObjects::Base do
       end
 
       bunny = double(Bunny).as_null_object
-      Bunny.stub(:new).and_return(bunny)
+      allow(Bunny).to receive(:new).and_return(bunny)
       channel = double(Bunny::Channel)
-      channel.should_receive(:prefetch).with(1)
+      expect(channel).to receive(:prefetch).with(1)
 
-      bunny.stub(:create_channel).and_return(channel)
+      allow(bunny).to receive(:create_channel).and_return(channel)
 
       worker  = MyWorker.new
       consumer = MyDaemon.get_consumer
-      MyDaemon.stub(:get_consumer).and_return(consumer)
+      allow(MyDaemon).to receive(:get_consumer).and_return(consumer)
 
-      MyWorker.should_receive(:new).
+      expect(MyWorker).to receive(:new).
         with(channel, consumer, {
               :queue_name => 'queue',
               :logger     => MyDaemon.logger,
               :arguments  => {}
         }).
         and_return(worker)
-      worker.should_receive(:start)
+      expect(worker).to receive(:start)
 
       MyDaemon.run
     end

--- a/spec/lib/daemon_objects/consumer_base_spec.rb
+++ b/spec/lib/daemon_objects/consumer_base_spec.rb
@@ -19,7 +19,7 @@ describe DaemonObjects::ConsumerBase do
       h = Harness.new(:logger => MemoryLogger::Logger.new)
       h.handle_message({:x => 1})
 
-      h.payloads_received.should == [{:x => 1}]
+      expect(h.payloads_received).to eq([{:x => 1}])
     end
   end
 
@@ -29,17 +29,17 @@ describe DaemonObjects::ConsumerBase do
 
     it 'should set logger' do
       h = harness.new(:logger => logger)
-      h.logger.should == logger
+      expect(h.logger).to eq(logger)
     end
 
     it 'should set app_directory' do
       h = harness.new(:app_directory => 'app_dir')
-      h.app_directory.should == 'app_dir'
+      expect(h.app_directory).to eq('app_dir')
     end
 
     it 'should set environment' do
       h = harness.new(:environment => 'environment')
-      h.environment.should == 'environment'
+      expect(h.environment).to eq('environment')
     end
   end
 

--- a/spec/lib/daemon_objects/logging_spec.rb
+++ b/spec/lib/daemon_objects/logging_spec.rb
@@ -15,20 +15,20 @@ describe DaemonObjects::Logging do
     it 'should create a logger at log/log_filename path' do
       logger = MemoryLogger::Logger.new
 
-      Logger.stub(:new).
+      allow(Logger).to receive(:new).
         with("#{harness.log_directory}/#{harness.log_filename}").
         and_return(logger)
 
       harness.logger.info("starting consumer")
 
-      logger.logged_output.should =~ /starting consumer/
+      expect(logger.logged_output).to match(/starting consumer/)
     end
   end
 
   describe '#create_logger' do
     it 'should create a logger with timestamp formatting' do
       logger = harness.logger
-      logger.formatter.class.should == ::Logger::Formatter
+      expect(logger.formatter.class).to eq(::Logger::Formatter)
     end
   end
 
@@ -44,13 +44,13 @@ describe DaemonObjects::Logging do
     end
 
     it 'should underscore name for log file' do
-      MyDaemon.log_filename.should == "my_daemon.log"
+      expect(MyDaemon.log_filename).to eq("my_daemon.log")
     end
   end
 
   describe '#log_directory' do
     it "should use 'log' for default log path" do
-      harness.log_directory.to_s.should == File.join(harness.app_directory, "log")
+      expect(harness.log_directory.to_s).to eq(File.join(harness.app_directory, "log"))
     end
   end
 

--- a/spec/lib/daemon_objects/runner_spec.rb
+++ b/spec/lib/daemon_objects/runner_spec.rb
@@ -33,13 +33,13 @@ describe DaemonObjects::AmqpSupport do
 
     bunny = double(Bunny).as_null_object
     # First attempt should raise and retry
-    Bunny.should_receive(:new).
+    expect(Bunny).to receive(:new).
       with('amqp://localhost:4567'){
         raise Bunny::TCPConnectionFailed.new("could not connect", "localhost", 4567)
       }
 
     # Second attempt succeeds to exit spec
-    Bunny.should_receive(:new).
+    expect(Bunny).to receive(:new).
       with('amqp://localhost:4567').and_return(bunny)
     MyDaemon.run
   end
@@ -55,7 +55,7 @@ describe DaemonObjects::AmqpSupport do
       end
     end
 
-    Bunny.should_receive(:new).twice.
+    expect(Bunny).to receive(:new).twice.
       with('amqp://localhost:4567').and_return(bunny)
 
     MyDaemon.run

--- a/spec/lib/daemon_objects_spec.rb
+++ b/spec/lib/daemon_objects_spec.rb
@@ -4,14 +4,14 @@ describe DaemonObjects do
   describe '#daemons' do
     it 'should get daemons from daemon_path' do
       DaemonObjects.daemon_path = File.join(FIXTURES_PATH, "daemon_path_spec")
-      DaemonObjects.daemons.sort.should == ["daemon_one", "daemon_two"]
+      expect(DaemonObjects.daemons.sort).to eq(["daemon_one", "daemon_two"])
     end
   end
 
   describe '#get_daemon_name' do
     it 'should parse out path and Daemon.rb' do
       path = File.join(FIXTURES_PATH, "daemon_path_spec/daemon_one_daemon.rb")
-      DaemonObjects.get_daemon_name(path).should == "daemon_one"
+      expect(DaemonObjects.get_daemon_name(path)).to eq("daemon_one")
     end
   end
 
@@ -35,7 +35,7 @@ describe DaemonObjects do
       end
 
       it 'should use Rails.env if Rails is defined' do
-        DaemonObjects.environment.should == Rails.env
+        expect(DaemonObjects.environment).to eq(Rails.env)
       end
     end
 
@@ -48,12 +48,12 @@ describe DaemonObjects do
         ENV["DAEMON_ENV"] = nil
       end
       it 'should use environment variable if Rails is not defined' do
-        DaemonObjects.environment.should == ENV["DAEMON_ENV"]
+        expect(DaemonObjects.environment).to eq(ENV["DAEMON_ENV"])
       end
     end
 
     it 'should be development if not Rails and no environment set' do
-      DaemonObjects.environment.should == "development"
+      expect(DaemonObjects.environment).to eq("development")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,6 @@ Dir[File.join(SPEC_PATH, "support/**/*.rb")].each{|f| require f}
 FIXTURES_PATH = File.join(SPEC_PATH, "fixtures")
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
# Overview

This pull request is to update the test specifications to be compliant with version 3.x of Rspec. The development/test dependency on Rspec has also been set to ~> 3.1. I also removed a deprecated configuration setting that will always set to `true` for Rspec 3.x. This configuration change was to remove `config.treat_symbols_as_metadata_keys_with_true_values = true`.
# Transpec Report

This conversion is done by Transpec 2.3.8 with the following command:
    transpec
- 22 conversions
  from: obj.should
    to: expect(obj).to
- 19 conversions
  from: == expected
    to: eq(expected)
- 11 conversions
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
- 9 conversions
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
- 2 conversions
  from: =~ /pattern/
    to: match(/pattern/)
- 2 conversions
  from: obj.should_not_receive(:message)
    to: expect(obj).not_to receive(:message)

For more details: https://github.com/yujinakayama/transpec#supported-conversions
