### PR TITLE
ActiveSupport update to 4.1.x

### DIFF
--- a/daemon_objects.gemspec
+++ b/daemon_objects.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "daemons", "~> 1.1"
-  spec.add_dependency "activesupport", "~> 3.2"
+  spec.add_dependency "activesupport", "~> 4.1"
   spec.add_dependency "bunny", "~> 1.1.0"
   spec.add_dependency "rake"
 


### PR DESCRIPTION
# Overview

This pull request changes the _daemon_objects_ gem dependency to ActiveSupport 4.1.x from 3.2.x. The specs all pass and it looks like the only real dependencies were the Logger and string extensions. I could have missed others, but those were the ones that stood out. I did not see any need to update specs related to these dependencies.
# Test Dependency Note

Running bundle install will load the latest Rspec (3.1.x), which will complain about the specs in this PR with deprecation warnings. A separate pull request #8 will update the specs to remove these warnings.
