### PR TITLE
Update railtie to require the local rake.rb file 

### DIFF
--- a/lib/daemon_objects/railtie.rb
+++ b/lib/daemon_objects/railtie.rb
@@ -1,6 +1,5 @@
 class Railtie < Rails::Railtie
   rake_tasks do
-    require "daemon_objects/loader"
-    load File.join(File.dirname(__FILE__), "tasks/daemon_objects.rake")
+    require_relative "rake"
   end
 end if defined?(Rails)


### PR DESCRIPTION
## Overview
This pull request modifies the railtie so that the corresponding rake tasks are loaded if Rails is present. This PR should close out Issue #6. The `rake.rb` did not need to be updated, since it already required the 'loader'.

With this update it might be worthwhile to bump the version to the next major number (e.g. 0.2.0). This release would also include to the Rails 4.1.x dependency that was added, since the 0.1.9 release.